### PR TITLE
Add support for NTP server definition

### DIFF
--- a/ignition.go
+++ b/ignition.go
@@ -15,7 +15,7 @@ const smallIgnition = `
   "networkd": {
     "units": [
       {
-        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/30\nGateway={{ .Gateway }}{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}",
+        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/30\nGateway={{ .Gateway }}{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}",
         "name": "00-eth0.network"
       }
     ]
@@ -37,4 +37,5 @@ type NodeSetup struct {
 	Hostname   string
 	IfaceIP    string
 	MainConfig string
+	NTPServers []string
 }


### PR DESCRIPTION
On many on-prem environments the access to Internet from tenant nodes might be
limited and in case of NTP there is often internal NTP server available. Allow
configuration of NTP servers when generating VM network interface unit.

While here, fix DNS server requirement check & add support for trimming extra
whitespace of those strings.

Towards https://github.com/giantswarm/giantswarm/issues/6740