### PR TITLE
Correct help text to match actual usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,10 +38,10 @@ func mainError() error {
 	}
 
 	bridgeIP := flag.String("bridge-ip", "", "IP address of the bridge (used to retrieve ip and gateway).")
-	dnsServers := flag.String("dns-servers", "", "Colon separated list of DNS servers.")
+	dnsServers := flag.String("dns-servers", "", "Comma separated list of DNS servers.")
 	hostname := flag.String("hostname", "", "Hostname of the tenant node.")
 	mainConfig := flag.String("main-config", "", "Path to main ignition config (appended to small).")
-	ntpServers := flag.String("ntp-servers", "", "Colon separated list of NTP servers.")
+	ntpServers := flag.String("ntp-servers", "", "Comma separated list of NTP servers.")
 	out := flag.String("out", "", "Path to save resulting ignition config.")
 	flag.Parse()
 


### PR DESCRIPTION
Delimiter is a comma: https://github.com/giantswarm/qemu-node-setup/blob/master/main.go#L17