### PR TITLE
Remove flannel networking

### DIFF
--- a/ignition.go
+++ b/ignition.go
@@ -15,7 +15,7 @@ const smallIgnition = `
   "networkd": {
     "units": [
       {
-        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/30\nGateway={{ .Gateway }}{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}",
+        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/32\nGateway={{ .Gateway }}{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}",
         "name": "00-eth0.network"
       }
     ]

--- a/ignition.go
+++ b/ignition.go
@@ -15,7 +15,7 @@ const smallIgnition = `
   "networkd": {
     "units": [
       {
-        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/32\nGateway={{ .Gateway }}{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}",
+        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/32\n{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}\n[Route]Destination={{.Gateway}}/32\nScope=link\n[Route]\nGateway={{.Gateway}}",
         "name": "00-eth0.network"
       }
     ]

--- a/ignition.go
+++ b/ignition.go
@@ -15,7 +15,7 @@ const smallIgnition = `
   "networkd": {
     "units": [
       {
-        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/32\n{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}\n[Route]Destination={{.Gateway}}/32\nScope=link\n[Route]\nGateway={{.Gateway}}",
+        "contents": "[Match]\nName=eth0\n\n[Network]\nAddress={{ .IfaceIP }}/32\n{{range $srv := .DNSServers }}\nDNS={{ $srv }}{{ end }}{{range $srv := .NTPServers }}\nNTP={{ $srv }}{{ end }}\n[Route]\nDestination={{.Gateway}}/32\nScope=link\n[Route]\nGateway={{.Gateway}}",
         "name": "00-eth0.network"
       }
     ]

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	serversDelimiter = ","
+	gateway          = "169.254.1.1"
 )
 
 func dupIP(ip net.IP) net.IP {
@@ -33,11 +34,7 @@ func main() {
 func mainError() error {
 	var err error
 
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	bridgeIP := flag.String("bridge-ip", "", "IP address of the bridge (used to retrieve ip and gateway).")
+	nodeIP := flag.String("node-ip", "", "IP address of the node")
 	dnsServers := flag.String("dns-servers", "", "Colon separated list of DNS servers.")
 	hostname := flag.String("hostname", "", "Hostname of the tenant node.")
 	mainConfig := flag.String("main-config", "", "Path to main ignition config (appended to small).")
@@ -64,15 +61,6 @@ func mainError() error {
 		}
 	}
 
-	ip := net.ParseIP(*bridgeIP)
-	ip = ip.To4()
-	if ip == nil {
-		return microerror.New("bridge-ip should be a valid IP address")
-	}
-
-	ifaceIP := dupIP(ip)
-	ifaceIP[3]++
-
 	mainConfigData, err := ioutil.ReadFile(*mainConfig)
 	if err != nil {
 		return microerror.Mask(err)
@@ -80,9 +68,9 @@ func mainError() error {
 
 	nodeSetup := NodeSetup{
 		DNSServers: dnsServersList,
-		Gateway:    ip.String(),
+		Gateway:    gateway,
 		Hostname:   *hostname,
-		IfaceIP:    ifaceIP.String(),
+		IfaceIP:    *nodeIP,
 		MainConfig: base64.StdEncoding.EncodeToString(mainConfigData),
 		NTPServers: ntpServersList,
 	}


### PR DESCRIPTION
adjust network setting to work without flannel magic

the final network file looks like this:
```
[Match]
Name=eth0

[Network]
Address=192.168.63.253/32

DNS=8.8.8.8
DNS=8.8.4.4
NTP=146.0.32.144
NTP=129.70.132.33
[Route]
Destination=169.254.1.1/32
Scope=link
[Route]
Gateway=169.254.1.1
```

where `192.168.63.253/32` is calico IP from the original container eth0

routes are same as they would be inside of container